### PR TITLE
Add cloudflare-tunnel-remote chart with changes merged in

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --config ct.yaml --helm-extra-set-args "--set cloudflare-tunnel-remote.cloudflare.tunnel_token=${{ secrets.CF_TUNNEL_TOKEN }}"
+        run: ct install --config ct.yaml --helm-extra-set-args "--set cloudflare-tunnel-remote.cloudflare.tunnel_token=${{ secrets.CF_TUNNEL_TOKEN }} --set cloudflare.tunnel_token=${{ secrets.CF_TUNNEL_TOKEN }}"
 
       - name: Remove Teleport token
         if: always()

--- a/charts/cloudflare-tunnel-remote/Chart.yaml
+++ b/charts/cloudflare-tunnel-remote/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: cloudflare-tunnel-remote
+description: Deployment of a remotely managed tunnel that has already been provisioned in Cloudflare
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.2
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "latest"
+
+# Let's look professional with a Cloudflare icon.
+icon: https://developers.cloudflare.com/cloudflare-one/favicon-32x32.png

--- a/charts/cloudflare-tunnel-remote/templates/_helpers.tpl
+++ b/charts/cloudflare-tunnel-remote/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cloudflare-tunnel-remote.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cloudflare-tunnel-remote.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cloudflare-tunnel-remote.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cloudflare-tunnel-remote.labels" -}}
+helm.sh/chart: {{ include "cloudflare-tunnel-remote.chart" . }}
+{{ include "cloudflare-tunnel-remote.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cloudflare-tunnel-remote.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cloudflare-tunnel-remote.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cloudflare-tunnel-remote.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cloudflare-tunnel-remote.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/cloudflare-tunnel-remote/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cloudflare-tunnel-remote.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel-remote.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      pod: cloudflared
+  template:
+    metadata:
+      creationTimestamp: null
+      annotations:
+        # These are here so the deployment rolls when the config or secret change.
+        checksum/secret: {{ .Values.cloudflare.tunnel_token | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        pod: cloudflared
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      serviceAccountName: {{ include "cloudflare-tunnel-remote.fullname" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+
+      containers:
+        - name: cloudflared
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - cloudflared
+            - tunnel
+            # We can regulate the cloudflared version via an image tag.
+            - --no-autoupdate
+            # In a k8s environment, the metrics server needs to listen outside the pod it runs on.
+            # The address 0.0.0.0:2000 allows any pod in the namespace.
+            - --metrics
+            - 0.0.0.0:2000
+            - run
+          env:
+          - name: TUNNEL_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.cloudflare.secretName | default (include "cloudflare-tunnel-remote.fullname" .) }}
+                key: {{ .Values.cloudflare.secretKey | default "tunnelToken" }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              # Cloudflared has a /ready endpoint which returns 200 if and only if
+              # it has an active connection to the edge.
+              path: /ready
+              port: 2000
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      affinity:
+        {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 10
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                  {{- range $k, $v := include "cloudflare-tunnel-remote.selectorLabels" . | fromYaml }}
+                    - key: {{ $k }}
+                      operator: In
+                      values:
+                        - {{ $v }}
+                  {{- end }}
+      {{- end }}
+
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/cloudflare-tunnel-remote/templates/secret.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if and (.Values.cloudflare.tunnel_token) (not .Values.cloudflare.secretName) }}
+# This credentials secret allows cloudflared to authenticate itself
+# to the Cloudflare infrastructure.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cloudflare-tunnel-remote.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel-remote.labels" . | nindent 4 }}
+stringData:
+  {{ .Values.cloudflare.secretKey }}: {{ .Values.cloudflare.tunnel_token }}
+{{- end }}

--- a/charts/cloudflare-tunnel-remote/templates/service.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cloudflare-tunnel-remote.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel-remote.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 2000
+      targetPort: 2000
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "cloudflare-tunnel-remote.selectorLabels" . | nindent 4 }}

--- a/charts/cloudflare-tunnel-remote/templates/serviceaccount.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+# Here we create a service account with no privileges to run the
+# deployment - just in case the default service account is different.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cloudflare-tunnel-remote.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel-remote.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/cloudflare-tunnel-remote/templates/servicemonitor.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/servicemonitor.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "cloudflare-tunnel-remote.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel-remote.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  jobLabel: {{ template "cloudflare-tunnel-remote.fullname" . }}
+  endpoints:
+  - port: metrics
+    {{- if .Values.serviceMonitor.path }}
+    path: {{ .Values.serviceMonitor.path }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+    {{ toYaml .Values.serviceMonitor.relabelings | indent 4 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.honorLabels }}
+    honorLabels: true
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "cloudflare-tunnel-remote.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/cloudflare-tunnel-remote/values.yaml
+++ b/charts/cloudflare-tunnel-remote/values.yaml
@@ -1,0 +1,78 @@
+# Default values for cloudflare-tunnel.
+
+# Cloudflare parameters.
+cloudflare:
+  tunnel_token: ""
+  # If defined, no secret is created for the credentials, and instead, the secret referenced is used
+  secretName: null
+  # the key of the secret where the token is stored
+  secretKey: "tunnelToken"
+
+image:
+  repository: cloudflare/cloudflared
+  pullPolicy: IfNotPresent
+  # If supplied, this overrides "latest"
+  tag: ""
+
+replicaCount: 2
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+# Security items common to everything in the pod.  Here we require that it
+# does not run as the user defined in the image, literally named "nonroot".
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+
+# Security items for one container. We lock it down.
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+# Default affinity is to spread out over nodes; use this to override.
+affinity: {}
+
+serviceMonitor:
+  # -- Enable this if you're using https://github.com/coreos/prometheus-operator
+  enabled: false
+  # -- Interval at which endpoints should be scraped.
+  interval: 30s
+  # -- Add custom labels to the ServiceMonitor resource
+  additionalLabels: {}
+    # prometheus: kube-prometheus
+  # -- Chooses the metric’s labels on collisions with target labels.
+  honorLabels: false
+  # -- Path to scrape metrics
+  path: /metrics
+  # -- Timeout for scrape metrics request
+  scrapeTimeout: 10s

--- a/charts/cloudflare-tunnel-remote/values.yaml
+++ b/charts/cloudflare-tunnel-remote/values.yaml
@@ -76,3 +76,7 @@ serviceMonitor:
   path: /metrics
   # -- Timeout for scrape metrics request
   scrapeTimeout: 10s
+  # -- Relabel metrics
+  metricRelabelings: null
+  # -- Relalabel
+  relabelings: null


### PR DESCRIPTION
There are several PRs that add things that we need to the [upstream cloudflare-tunnel-remote chart](https://github.com/cloudflare/helm-charts/tree/main/charts/cloudflare-tunnel-remote). We will maintain our own copy of the chart with these changes merged in until the following PRs are merged upstream:

* https://github.com/cloudflare/helm-charts/pull/65
* https://github.com/cloudflare/helm-charts/pull/63
* https://github.com/cloudflare/helm-charts/pull/49